### PR TITLE
Modify --proxy to support multiple SNMP port

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ Cacti CHANGELOG
 -issue#2502: Unable to have a min or max value for RRDfile at zero '0'
 -issue#2503: The Cacti Statistics Device Template is not in the default Cacti
 -feature: Update phpseclib to version 2.0.15
+-feature: Support multiple SNMP ports when adding devices via CLI
 
 1.2.2
 -issue#599: Aggregate graph templates assume AVG consolidation function

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,7 +35,7 @@ Cacti CHANGELOG
 -issue#2502: Unable to have a min or max value for RRDfile at zero '0'
 -issue#2503: The Cacti Statistics Device Template is not in the default Cacti
 -feature: Update phpseclib to version 2.0.15
--feature: Support multiple SNMP ports when adding devices via CLI
+-feature#2515: Support multiple SNMP ports when adding devices via CLI
 
 1.2.2
 -issue#599: Aggregate graph templates assume AVG consolidation function

--- a/cli/add_device.php
+++ b/cli/add_device.php
@@ -343,7 +343,7 @@ if (cacti_sizeof($parms)) {
 		if ($phost['snmp_version'] < '3' && $snmp_ver < '3') {
 			if ($snmp_ver == 0 && $proxy) {
 				// proxy but for no snmp
-			} elseif ($phost['snmp_community'] != $community) {
+			} elseif ($phost['snmp_community'] != $community || $phost['snmp_port'] != $snmp_port) {
 				if ($proxy) {
 					// assuming an snmp-proxy
 				} else {


### PR DESCRIPTION
Useful when multiple devices behind a NAT with a single IP address